### PR TITLE
Update to Python 3.13

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3
+FROM python:3.13
 
 WORKDIR /app
 

--- a/app/common/util/test.py
+++ b/app/common/util/test.py
@@ -1,5 +1,7 @@
 import sys
-sys.path.append('/Users/yk/work/fastAPI/typed_functional_python/app')
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parent.parent.parent))
 
 from common.util.result import Err, From, Ok, Result
 from dataclasses import dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 packages = []
 
 [tool.poetry.dependencies]
-python = "^3.12"
+python = "^3.13"
 fastapi = "^0.104.0"
 uvicorn = "^0.23.1"
 python-dotenv = "^1.0.0"
@@ -23,7 +23,7 @@ requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.ruff]
-target-version = "py312"
+target-version = "py313"
 line-length = 100
 select = [
   "E", # pycodestyle errors
@@ -44,9 +44,9 @@ unfixable = [
 ]
 
 [tool.mypy]
-python_version = 3.12
+python_version = 3.13
 strict = true
 
 [tool.black]
-target-version= ['py312']
+target-version= ['py313']
 line-length = 100


### PR DESCRIPTION
Related to #1

Update Python version to 3.13 and make necessary changes for compatibility.

* **pyproject.toml**
  - Update the Python version to `^3.13`.
  - Update the `target-version` in the `[tool.ruff]` section to `py313`.
  - Update the `python_version` in the `[tool.mypy]` section to `3.13`.
  - Update the `target-version` in the `[tool.black]` section to `py313`.

* **Dockerfile**
  - Change the base image from `python:3` to `python:3.13`.

* **app/common/util/test.py**
  - Replace `sys.path.append` method with a more dynamic approach using `Path`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/yodakeisuke/typed-functional-python/issues/1?shareId=098e0f08-a0ad-4db9-8c4b-21757ec866b6).